### PR TITLE
Made Github organisation link clickable

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,7 +202,7 @@
 
         <div id="HackerspaceBasicInfo" class="col-md-6 col-sm-12" data-aos="fade">
           <p class="oi oi-location" title="location"> Multimedia University Cyberjaya</p><br>
-          <p class="oi oi-star" title="star"> GitHub: github.com/hackerspacemmu</p><br>
+          <p class="oi oi-star" title="star"> GitHub: <a href="https://github.com/hackerspacemmu" target="_">https://github.com/hackerspacemmu</a></p><br>
           <p class="oi oi-inbox" title="inbox"> Email: hackerspacemmu@gmail.com</p><br>
         </div>
 


### PR DESCRIPTION
What did I change?

1. I made the Github organisation link clickable.

Screenshot: 
<img width="485" alt="Screenshot 2021-08-19 at 10 09 34 PM" src="https://user-images.githubusercontent.com/53941721/130083472-38c2272f-f1ac-42df-8a6b-08eaf75833b3.png">

Requesting review from @LiewKuanYung 